### PR TITLE
Adds Rails root to the load path in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,7 @@ $LOAD_PATH << Rails.root
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,7 @@
+$LOAD_PATH << Rails.root
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
In order to keep using explicit requires in SectorPresenter, we need to
add the Rails root to the load path.

The decision to use explicit requires, instead of relying on Rails implicit
loading, was to enable fast unit testing
