### PR TITLE
Nest groups under a "details" block.

### DIFF
--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -18,7 +18,9 @@ class SectorPresenter
       {
         title: sector_content.title,
         parent: sector_content.parent,
-        groups: groups
+        details: {
+          groups: groups
+        }
       }
     end
   end

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -38,29 +38,31 @@ RSpec.describe SectorPresenter, type: :model do
       expect(presenter).not_to be_empty
       expect(presenter.to_hash).to include(
         title: "Offshore",
-        groups: [
-          {
-            name: "A to Z",
-            contents: [
-              {
-                title: "North Sea shipping lanes",
-                web_url: "https://www.example.com/north-sea-shipping-lanes"
-              },
-              {
-                title: "Oil rig safety requirements",
-                web_url: "https://www.example.com/oil-rig-safety-requirements"
-              },
-              {
-                title: "Oil rig staffing",
-                web_url: "https://www.example.com/oil-rig-staffing"
-              },
-              {
-                title: "Undersea piping restrictions",
-                web_url: "https://www.example.com/undersea-piping-restrictions"
-              }
-            ]
-          }
-        ]
+        details: {
+          groups: [
+            {
+              name: "A to Z",
+              contents: [
+                {
+                  title: "North Sea shipping lanes",
+                  web_url: "https://www.example.com/north-sea-shipping-lanes"
+                },
+                {
+                  title: "Oil rig safety requirements",
+                  web_url: "https://www.example.com/oil-rig-safety-requirements"
+                },
+                {
+                  title: "Oil rig staffing",
+                  web_url: "https://www.example.com/oil-rig-staffing"
+                },
+                {
+                  title: "Undersea piping restrictions",
+                  web_url: "https://www.example.com/undersea-piping-restrictions"
+                }
+              ]
+            }
+          ]
+        }
       )
     end
 
@@ -87,39 +89,41 @@ RSpec.describe SectorPresenter, type: :model do
       expect(presenter).not_to be_empty
       expect(presenter.to_hash).to include({
         title: "Offshore",
-        groups: [
-          {
-            name: "Oil rigs",
-            contents: [
-              {
-                title: "Oil rig safety requirements",
-                web_url: "https://www.example.com/oil-rig-safety-requirements"
-              },
-              {
-                title: "Oil rig staffing",
-                web_url: "https://www.example.com/oil-rig-staffing"
-              }
-            ]
-          },
-          {
-            name: "Piping",
-            contents: [
-              {
-                title: "Undersea piping restrictions",
-                web_url: "https://www.example.com/undersea-piping-restrictions"
-              }
-            ]
-          },
-          {
-            name: "Other",
-            contents: [
-              {
-                title: "North Sea shipping lanes",
-                web_url: "https://www.example.com/north-sea-shipping-lanes"
-              }
-            ]
-          }
-        ]
+        details: {
+          groups: [
+            {
+              name: "Oil rigs",
+              contents: [
+                {
+                  title: "Oil rig safety requirements",
+                  web_url: "https://www.example.com/oil-rig-safety-requirements"
+                },
+                {
+                  title: "Oil rig staffing",
+                  web_url: "https://www.example.com/oil-rig-staffing"
+                }
+              ]
+            },
+            {
+              name: "Piping",
+              contents: [
+                {
+                  title: "Undersea piping restrictions",
+                  web_url: "https://www.example.com/undersea-piping-restrictions"
+                }
+              ]
+            },
+            {
+              name: "Other",
+              contents: [
+                {
+                  title: "North Sea shipping lanes",
+                  web_url: "https://www.example.com/north-sea-shipping-lanes"
+                }
+              ]
+            }
+          ]
+        }
       })
     end
 

--- a/spec/requests/sector_spec.rb
+++ b/spec/requests/sector_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Requests for specialist sectors", type: :request do
 
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)["title"]).to eq("Offshore")
-      expect(JSON.parse(response.body)).to include(
+      expect(JSON.parse(response.body)["details"]).to include(
         "groups" => [
           "name" => "A to Z",
           "contents" => [
@@ -80,7 +80,7 @@ RSpec.describe "Requests for specialist sectors", type: :request do
       get_specialist_sector "oil-and-gas/offshore"
 
       expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)).to include(
+      expect(JSON.parse(response.body)["details"]).to include(
         "groups" => [
           "name" => "A test group",
           "contents" => [


### PR DESCRIPTION
This is in line with other APIs across GOV.UK.
