### PR TITLE
Add a /healthcheck request for status monitoring

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,26 @@
+class HealthcheckController < ApplicationController
+
+  def index
+    render json: {
+      status: service_status
+    }
+  end
+
+private
+
+  def service_status
+    check_content_api
+    check_content_store
+    "ok"
+  rescue GdsApi::HTTPErrorResponse
+    "critical"
+  end
+
+  def check_content_api
+    CollectionsAPI.services(:content_api).sections
+  end
+
+  def check_content_store
+    CollectionsAPI.services(:content_store).content_item('/does/not/exist')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   get "specialist-sectors/*id", to: "specialist_sectors#show"
+  get 'healthcheck' => 'healthcheck#index'
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+require 'gds_api/test_helpers/content_api'
+require 'gds_api/test_helpers/content_store'
+
+RSpec.describe "Healthcheck requests", type: :request do
+  include GdsApi::TestHelpers::ContentApi
+  include GdsApi::TestHelpers::ContentStore
+
+  before :each do
+    content_api_has_root_tags("section", ["some", "slugs"])
+    content_store_does_not_have_item('/does/not/exist')
+  end
+
+  context "when content-api and content-store are both available" do
+    it 'reports an "OK" status' do
+      get "/healthcheck"
+
+      expect(response.status).to eq(200)
+      expect(json_response["status"]).to eq("ok")
+    end
+  end
+
+  context "when content-api returns an error response" do
+    before do
+      content_api_isnt_available
+    end
+
+    it 'reports a critical error' do
+      get "/healthcheck"
+      expect(response.status).to eq(200)
+      expect(json_response["status"]).to eq("critical")
+    end
+  end
+
+  context "when content-store returns an error response" do
+    before do
+      content_store_isnt_available
+    end
+
+    it 'reports a critical error' do
+      get "/healthcheck"
+      expect(response.status).to eq(200)
+      expect(json_response["status"]).to eq("critical")
+    end
+  end
+
+
+private
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  def content_api_isnt_available
+    stub_request(:any, /#{Plek.new.find('contentapi')}*/).
+        to_return(status: 503)
+  end
+end


### PR DESCRIPTION
Responds with a JSON payload that reports on the current status of the application. If it cannot connect to either content-api or content-store it returns a "critical" status, otherwise it returns an "OK" status.

Tracker: https://www.pivotaltracker.com/story/show/78146674
