### PR TITLE
Exclude untagged content when presenting for collections frontend.

### DIFF
--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -69,14 +69,7 @@ private
     curated_sector.groups.map do |group|
       {
         name: group[:name],
-        contents: group[:contents].map { |api_url|
-          content = find_content(api_url)
-
-          {
-            title: content[:title],
-            web_url: content[:web_url]
-          }
-        }
+        contents: inflated_content(group[:contents])
       }
     end
   end
@@ -85,5 +78,20 @@ private
     sector_content.results.find do |content|
       content[:id] == api_url
     end
+  end
+
+  def inflated_content(api_urls)
+    inflated = []
+
+    api_urls.each do |api_url|
+      if (content = find_content(api_url))
+        inflated << {
+          title: content[:title],
+          web_url: content[:web_url]
+        }
+      end
+    end
+
+    inflated
   end
 end

--- a/spec/models/curated_sector_spec.rb
+++ b/spec/models/curated_sector_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe CuratedSector, type: :model do
             "http://example.com/api/oil-rig-staffing.json"
           ],
           [
-            "http://example.com/api/undersea-piping-restrictions.json"
+            "http://example.com/api/undersea-piping-restrictions.json",
+            "http://example.com/api/an-untagged-document-about-oil.json"
           ],
           [
             "http://example.com/api/north-sea-shipping-lanes.json"

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SectorPresenter, type: :model do
       stub_content_store_with_content
     end
 
-    it "returns grouped content inflated with title and web URL" do
+    it "returns grouped content inflated with title and web URL, removing untagged content" do
       presenter = SectorPresenter.new("oil-and-gas/offshore")
 
       expect(presenter).not_to be_empty
@@ -135,6 +135,16 @@ RSpec.describe SectorPresenter, type: :model do
         "slug" => "oil-and-gas",
         "title" => "Oil and gas"
       )
+    end
+
+    it "removes content which has been untagged" do
+      presenter = SectorPresenter.new("oil-and-gas/offshore")
+
+      piping_group = presenter.to_hash[:details][:groups].find {|g| g[:name] == "Piping" }
+      expect(piping_group[:contents]).to eq([{
+        title: "Undersea piping restrictions",
+        web_url: "https://www.example.com/undersea-piping-restrictions"
+      }])
     end
   end
 end

--- a/spec/support/helpers/content_store_helpers.rb
+++ b/spec/support/helpers/content_store_helpers.rb
@@ -32,7 +32,8 @@ module ContentStoreHelpers
           {
             "name" => "Piping",
             "contents" => [
-              "http://example.com/api/undersea-piping-restrictions.json"
+              "http://example.com/api/undersea-piping-restrictions.json",
+              "http://example.com/api/an-untagged-document-about-oil.json"
             ]
           },
           {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/78470148

We do this in the publisher but it needs to be handled in the API too as content can be untagged after the curation was published.
