### PR TITLE
Filter out empty groups.

### DIFF
--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -41,7 +41,7 @@ private
 
   def groups
     if curated_sector
-      inflated_groups
+      filtered_groups
     else
       a_to_z_group
     end
@@ -63,6 +63,12 @@ private
         }
       }
     ]
+  end
+
+  def filtered_groups
+    inflated_groups.reject do |group|
+      group[:contents].empty?
+    end
   end
 
   def inflated_groups

--- a/spec/models/curated_sector_spec.rb
+++ b/spec/models/curated_sector_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CuratedSector, type: :model do
       it "provides the ordered groups hash (with indifferent access)" do
         sector = CuratedSector.find("oil-and-gas/offshore")
 
-        expect(sector.groups.map {|g| g[:name] }).to eq(["Oil rigs", "Piping", "Other"])
+        expect(sector.groups.map {|g| g[:name] }).to eq(["Oil rigs", "Piping", "A group with only untagged content", "Other"])
         expect(sector.groups.map {|g| g[:contents] }).to eq([
           [
             "http://example.com/api/oil-rig-safety-requirements.json",
@@ -37,6 +37,9 @@ RSpec.describe CuratedSector, type: :model do
           ],
           [
             "http://example.com/api/undersea-piping-restrictions.json",
+            "http://example.com/api/an-untagged-document-about-oil.json"
+          ],
+          [
             "http://example.com/api/an-untagged-document-about-oil.json"
           ],
           [

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SectorPresenter, type: :model do
       stub_content_store_with_content
     end
 
-    it "returns grouped content inflated with title and web URL, removing untagged content" do
+    it "returns grouped content inflated with title and web URL" do
       presenter = SectorPresenter.new("oil-and-gas/offshore")
 
       expect(presenter).not_to be_empty
@@ -140,11 +140,24 @@ RSpec.describe SectorPresenter, type: :model do
     it "removes content which has been untagged" do
       presenter = SectorPresenter.new("oil-and-gas/offshore")
 
-      piping_group = presenter.to_hash[:details][:groups].find {|g| g[:name] == "Piping" }
+      piping_group = find_group(presenter, "Piping")
+
       expect(piping_group[:contents]).to eq([{
         title: "Undersea piping restrictions",
         web_url: "https://www.example.com/undersea-piping-restrictions"
       }])
     end
+
+    it "removes groups where all the content has been untagged" do
+      presenter = SectorPresenter.new("oil-and-gas/offshore")
+
+      untagged_group = find_group(presenter, "A group with only untagged content")
+
+      expect(untagged_group).to be_nil
+    end
+  end
+
+  def find_group(presenter, name)
+    presenter.to_hash[:details][:groups].find {|g| g[:name] == name }
   end
 end

--- a/spec/support/helpers/content_store_helpers.rb
+++ b/spec/support/helpers/content_store_helpers.rb
@@ -37,6 +37,12 @@ module ContentStoreHelpers
             ]
           },
           {
+            "name" => "A group with only untagged content",
+            "contents" => [
+              "http://example.com/api/an-untagged-document-about-oil.json"
+            ]
+          },
+          {
             "name" => "Other",
             "contents" => [
               "http://example.com/api/north-sea-shipping-lanes.json"


### PR DESCRIPTION
These occur when all the curated content has been subsequently untagged from the topic.

https://www.pivotaltracker.com/story/show/78805208
