### PR TITLE
Support the 'start' parameter to paginate the latest feed

### DIFF
--- a/app/controllers/specialist_sectors_controller.rb
+++ b/app/controllers/specialist_sectors_controller.rb
@@ -1,6 +1,6 @@
 class SpecialistSectorsController < ApplicationController
   def show
-    presenter = SectorPresenter.new(params[:id])
+    presenter = SectorPresenter.new(params[:id], start: params[:start])
 
     render json: presenter.to_json, status: (presenter.empty? ? 404 : 200)
   end

--- a/app/controllers/specialist_sectors_controller.rb
+++ b/app/controllers/specialist_sectors_controller.rb
@@ -1,6 +1,9 @@
 class SpecialistSectorsController < ApplicationController
   def show
-    presenter = SectorPresenter.new(params[:id], start: params[:start])
+    presenter = SectorPresenter.new(params[:id],
+                  start: params[:start],
+                  count: params[:count],
+                )
 
     render json: presenter.to_json, status: (presenter.empty? ? 404 : 200)
   end

--- a/app/models/latest_changes.rb
+++ b/app/models/latest_changes.rb
@@ -15,7 +15,7 @@ class LatestChanges
   def self.build_search_query_for(slug, options)
     {
      count: "50",
-     start: options.fetch(:start, 0).to_s,
+     start: valid_start_value(options).to_s,
      filter_specialist_sectors: [slug],
      order: "-public_timestamp",
      fields: %w(title link latest_change_note public_timestamp)
@@ -36,5 +36,14 @@ class LatestChanges
 
   def total
     @contents['total'].to_i
+  end
+
+private
+  def self.valid_start_value(options)
+    if options[:start] && options[:start].to_i > 0
+      options[:start].to_i
+    else
+      0
+    end
   end
 end

--- a/app/models/latest_changes.rb
+++ b/app/models/latest_changes.rb
@@ -1,9 +1,9 @@
 require "active_support/core_ext/hash/indifferent_access"
 
 class LatestChanges
-  def self.find(slug)
+  def self.find(slug, search_query_opts={})
     search_client = CollectionsAPI.services(:rummager)
-    search_query = build_search_query_for(slug)
+    search_query = build_search_query_for(slug, search_query_opts)
 
     if (contents = search_client.unified_search(search_query)) && contents["results"]
       return self.new(contents)
@@ -12,9 +12,10 @@ class LatestChanges
     end
   end
 
-  def self.build_search_query_for(slug)
+  def self.build_search_query_for(slug, options)
     {
      count: "50",
+     start: options.fetch(:start, 0).to_s,
      filter_specialist_sectors: [slug],
      order: "-public_timestamp",
      fields: %w(title link latest_change_note public_timestamp)
@@ -27,5 +28,13 @@ class LatestChanges
 
   def results
     @contents["results"].map(&:with_indifferent_access)
+  end
+
+  def start
+    @contents['start'].to_i
+  end
+
+  def total
+    @contents['total'].to_i
   end
 end

--- a/app/models/latest_changes.rb
+++ b/app/models/latest_changes.rb
@@ -1,6 +1,9 @@
 require "active_support/core_ext/hash/indifferent_access"
 
 class LatestChanges
+  DEFAULT_RESULTS_PER_PAGE = 50
+  MAX_RESULTS_PER_PAGE = 100
+
   def self.find(slug, search_query_opts={})
     search_client = CollectionsAPI.services(:rummager)
     search_query = build_search_query_for(slug, search_query_opts)
@@ -14,7 +17,7 @@ class LatestChanges
 
   def self.build_search_query_for(slug, options)
     {
-     count: "50",
+     count: valid_count_value(options).to_s,
      start: valid_start_value(options).to_s,
      filter_specialist_sectors: [slug],
      order: "-public_timestamp",
@@ -45,5 +48,16 @@ private
     else
       0
     end
+  end
+
+  def self.valid_count_value(options)
+    count = options[:count]
+    count = count.nil? ? 0 : count.to_i
+    if count <= 0
+      count = DEFAULT_RESULTS_PER_PAGE
+    elsif count > MAX_RESULTS_PER_PAGE
+      count = MAX_RESULTS_PER_PAGE
+    end
+    count
   end
 end

--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -22,7 +22,9 @@ class SectorPresenter
         parent: sector_content.parent,
         details: {
           groups: groups,
-          documents: documents
+          documents: documents,
+          documents_start: latest_changes_content.start,
+          documents_total: latest_changes_content.total,
         }
       }
     end

--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -4,8 +4,9 @@ require "app/models/curated_sector"
 require "app/models/latest_changes"
 
 class SectorPresenter
-  def initialize(slug)
+  def initialize(slug, options = {})
     @slug = slug
+    @options = options
   end
 
   def empty?
@@ -33,6 +34,8 @@ class SectorPresenter
 
 private
 
+  attr_reader :options
+
   def sector_content
     @sector_content ||= SectorContent.find(@slug)
   end
@@ -42,7 +45,7 @@ private
   end
 
   def latest_changes_content
-    @latest_changes_content ||= LatestChanges.find(@slug)
+    @latest_changes_content ||= LatestChanges.find(@slug, start: options[:start])
   end
 
   def no_latest_changes?

--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -47,7 +47,10 @@ private
   end
 
   def latest_changes_content
-    @latest_changes_content ||= LatestChanges.find(@slug, start: options[:start])
+    @latest_changes_content ||= LatestChanges.find(@slug,
+                                  start: options[:start],
+                                  count: options[:count],
+                                )
   end
 
   def no_latest_changes?

--- a/spec/models/latest_changes_spec.rb
+++ b/spec/models/latest_changes_spec.rb
@@ -4,6 +4,17 @@ require "app/models/latest_changes"
 
 RSpec.describe LatestChanges, type: :model do
   describe ".find" do
+    let(:slug) { 'sluggy' }
+    let(:base_rummager_query) {
+      {
+        count: "50",
+        start: "0",
+        filter_specialist_sectors: [slug],
+        order: "-public_timestamp",
+        fields: %w(title link latest_change_note public_timestamp)
+      }
+    }
+
     context "with an empty rummager result set" do
       it "returns an empty results array" do
         rummager = double("rummager", unified_search: { "results" => [] })
@@ -40,22 +51,42 @@ RSpec.describe LatestChanges, type: :model do
 
         expect(latest_content.results[0]["title"]).to eq("Revenue and Customs Briefs")
       end
+
+      it 'returns information for pagination' do
+        rummager_results = {
+          'start' => '50',
+          'total' => '200',
+          'results' => [],
+        }
+
+        rummager = double("rummager", unified_search: rummager_results)
+        CollectionsAPI.services(:rummager, rummager)
+
+        latest_content = LatestChanges.find("topic_search")
+
+        expect(latest_content.start).to eq(50)
+        expect(latest_content.total).to eq(200)
+      end
     end
 
     it "it queries rummager for the latest changed content" do
       rummager = double("rummager")
-      slug = "sluggy"
-      query = {
-        count: "50",
-        filter_specialist_sectors: [slug],
-        order: "-public_timestamp",
-        fields: %w(title link latest_change_note public_timestamp)
-      }
       CollectionsAPI.services(:rummager, rummager)
 
-      expect(rummager).to receive(:unified_search).with(query)
+      expect(rummager).to receive(:unified_search).with(base_rummager_query)
 
       LatestChanges.find(slug)
+    end
+
+    it "passes the starting value into the rummager query" do
+      rummager = double("rummager")
+      CollectionsAPI.services(:rummager, rummager)
+
+      expect(rummager).to receive(:unified_search).with(
+        base_rummager_query.merge(start: '10')
+      )
+
+      LatestChanges.find(slug, start: 10)
     end
   end
 end

--- a/spec/models/latest_changes_spec.rb
+++ b/spec/models/latest_changes_spec.rb
@@ -123,5 +123,62 @@ RSpec.describe LatestChanges, type: :model do
         LatestChanges.find(slug, start: -10)
       end
     end
+
+    context 'count value' do
+      it 'passes the count value into the rummager query' do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
+
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(count: '20')
+        )
+
+        LatestChanges.find(slug, count: 20)
+      end
+
+      it 'uses the default count value when nil' do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
+
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(count: '50')
+        )
+
+        LatestChanges.find(slug, count: nil)
+      end
+
+      it 'uses the default count value when a blank string' do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
+
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(count: '50')
+        )
+
+        LatestChanges.find(slug, count: '')
+      end
+
+      it 'uses the default count value when less than zero' do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
+
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(count: '50')
+        )
+
+        LatestChanges.find(slug, count: -10)
+      end
+
+      it 'limits the count value to the maximum' do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
+
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(count: '100')
+        )
+
+        LatestChanges.find(slug, count: 1000)
+      end
+    end
   end
 end

--- a/spec/models/latest_changes_spec.rb
+++ b/spec/models/latest_changes_spec.rb
@@ -78,15 +78,50 @@ RSpec.describe LatestChanges, type: :model do
       LatestChanges.find(slug)
     end
 
-    it "passes the starting value into the rummager query" do
-      rummager = double("rummager")
-      CollectionsAPI.services(:rummager, rummager)
+    context 'start value' do
+      it "passes the starting value into the rummager query" do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
 
-      expect(rummager).to receive(:unified_search).with(
-        base_rummager_query.merge(start: '10')
-      )
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(start: '10')
+        )
 
-      LatestChanges.find(slug, start: 10)
+        LatestChanges.find(slug, start: 10)
+      end
+
+      it 'defaults to zero given a nil value' do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
+
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(start: '0')
+        )
+
+        LatestChanges.find(slug, start: nil)
+      end
+
+      it 'defaults to zero given a blank string' do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
+
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(start: '0')
+        )
+
+        LatestChanges.find(slug, start: '')
+      end
+
+      it 'defaults to zero given a negative number' do
+        rummager = double("rummager")
+        CollectionsAPI.services(:rummager, rummager)
+
+        expect(rummager).to receive(:unified_search).with(
+          base_rummager_query.merge(start: '0')
+        )
+
+        LatestChanges.find(slug, start: -10)
+      end
     end
   end
 end

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -73,7 +73,9 @@ RSpec.describe SectorPresenter, type: :model do
               public_updated_at: "2014-10-16T10:31:28+01:00",
               title: "North Sea shipping lanes",
             }
-          ]
+          ],
+          documents_start: 0,
+          documents_total: 0,
         }
       )
     end
@@ -143,7 +145,9 @@ RSpec.describe SectorPresenter, type: :model do
               public_updated_at: "2014-10-16T10:31:28+01:00",
               title: "North Sea shipping lanes",
             }
-          ]
+          ],
+          documents_start: 0,
+          documents_total: 0,
         }
       })
     end
@@ -157,6 +161,8 @@ RSpec.describe SectorPresenter, type: :model do
       presenter = SectorPresenter.new("oil-and-gas/offshore", start: 10)
       output = presenter.to_hash
 
+      expect(output[:details][:documents_start]).to eq(10)
+      expect(output[:details][:documents_total]).to eq(100)
     end
   end
 
@@ -214,7 +220,9 @@ RSpec.describe SectorPresenter, type: :model do
               public_updated_at: "2014-10-16T10:31:28+01:00",
               title: "North Sea shipping lanes",
             }
-          ]
+          ],
+          documents_start: 0,
+          documents_total: 0,
         }
       })
     end

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -152,13 +152,13 @@ RSpec.describe SectorPresenter, type: :model do
       })
     end
 
-    it 'passes the start value to the LatestChanges instance' do
+    it 'passes the start and count values to the LatestChanges instance' do
       mock_latest_changes = double('LatestChanges', start: 10, total: 100, results: [])
       expect(LatestChanges).to receive(:find)
-                                .with('oil-and-gas/offshore', start: 10)
+                                .with('oil-and-gas/offshore', start: 10, count: 50)
                                 .and_return(mock_latest_changes)
 
-      presenter = SectorPresenter.new("oil-and-gas/offshore", start: 10)
+      presenter = SectorPresenter.new("oil-and-gas/offshore", start: 10, count: 50)
       output = presenter.to_hash
 
       expect(output[:details][:documents_start]).to eq(10)

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -147,6 +147,17 @@ RSpec.describe SectorPresenter, type: :model do
         }
       })
     end
+
+    it 'passes the start value to the LatestChanges instance' do
+      mock_latest_changes = double('LatestChanges', start: 10, total: 100, results: [])
+      expect(LatestChanges).to receive(:find)
+                                .with('oil-and-gas/offshore', start: 10)
+                                .and_return(mock_latest_changes)
+
+      presenter = SectorPresenter.new("oil-and-gas/offshore", start: 10)
+      output = presenter.to_hash
+
+    end
   end
 
   context "when the sector is present and curated" do

--- a/spec/requests/sector_spec.rb
+++ b/spec/requests/sector_spec.rb
@@ -140,6 +140,8 @@ RSpec.describe "Requests for specialist sectors", type: :request do
       body = JSON.parse(response.body)
 
       expect(response.status).to eq(200)
+      expect(body['details']['documents_start']).to eq(50)
+      expect(body['details']['documents_total']).to eq(100)
     end
   end
 

--- a/spec/requests/sector_spec.rb
+++ b/spec/requests/sector_spec.rb
@@ -131,6 +131,16 @@ RSpec.describe "Requests for specialist sectors", type: :request do
           "public_updated_at" => "2014-10-16T10:31:28+01:00",
           "title" => "North Sea shipping lanes" })
     end
+
+    it 'accepts the "start" parameter' do
+      stub_rummager_with_paginated_content(start: 50, total: 100)
+
+      get_specialist_sector 'oil-and-gas/offshore?start=50'
+
+      body = JSON.parse(response.body)
+
+      expect(response.status).to eq(200)
+    end
   end
 
   def get_specialist_sector(slug)

--- a/spec/requests/sector_spec.rb
+++ b/spec/requests/sector_spec.rb
@@ -132,10 +132,10 @@ RSpec.describe "Requests for specialist sectors", type: :request do
           "title" => "North Sea shipping lanes" })
     end
 
-    it 'accepts the "start" parameter' do
-      stub_rummager_with_paginated_content(start: 50, total: 100)
+    it 'accepts the "start" and "count" parameters' do
+      stub_rummager_with_paginated_content(start: 50, count: 25, total: 100)
 
-      get_specialist_sector 'oil-and-gas/offshore?start=50'
+      get_specialist_sector 'oil-and-gas/offshore?start=50&count=25'
 
       body = JSON.parse(response.body)
 

--- a/spec/support/helpers/rummager_helpers.rb
+++ b/spec/support/helpers/rummager_helpers.rb
@@ -1,18 +1,22 @@
 require "config/initializers/services"
 
 module RummagerHelpers
+  def stub_rummager_result
+    {
+      "latest_change_note" => "This has changed",
+      "public_timestamp" => "2014-10-16T10:31:28+01:00",
+      "title" => "North Sea shipping lanes",
+      "link" => "/government/collections/north-sea-shipping-lanes",
+      "index" => "government",
+      "_id" => "/government/collections/north-sea-shipping-lanes",
+      "document_type" => "edition"
+    }
+  end
+
   def stub_rummager_with_content
     rummager_results = {
       "results" => [
-        {
-          "latest_change_note" => "This has changed",
-          "public_timestamp" => "2014-10-16T10:31:28+01:00",
-          "title" => "North Sea shipping lanes",
-          "link" => "/government/collections/north-sea-shipping-lanes",
-          "index" => "government",
-          "_id" => "/government/collections/north-sea-shipping-lanes",
-          "document_type" => "edition"
-        },
+        stub_rummager_result
       ]
     }
     rummager_double = double("rummager", unified_search: rummager_results)
@@ -22,6 +26,23 @@ module RummagerHelpers
   def stub_rummager_without_content
     rummager_results = {}
     rummager_double = double("rummager", unified_search: rummager_results)
+    rummager = CollectionsAPI.services(:rummager, rummager_double)
+  end
+
+  def stub_rummager_with_paginated_content(start:, total:)
+    rummager_response = {
+      'results' => [
+        stub_rummager_result
+      ],
+      'start' => start,
+      'total' => total,
+    }
+
+    rummager_double = double('rummager')
+    expect(rummager_double).to receive(:unified_search).with(
+      hash_including(start: start.to_s)
+    ).and_return(rummager_response)
+
     rummager = CollectionsAPI.services(:rummager, rummager_double)
   end
 end

--- a/spec/support/helpers/rummager_helpers.rb
+++ b/spec/support/helpers/rummager_helpers.rb
@@ -29,7 +29,7 @@ module RummagerHelpers
     rummager = CollectionsAPI.services(:rummager, rummager_double)
   end
 
-  def stub_rummager_with_paginated_content(start:, total:)
+  def stub_rummager_with_paginated_content(start:, total:, count:)
     rummager_response = {
       'results' => [
         stub_rummager_result
@@ -40,7 +40,7 @@ module RummagerHelpers
 
     rummager_double = double('rummager')
     expect(rummager_double).to receive(:unified_search).with(
-      hash_including(start: start.to_s)
+      hash_including(start: start.to_s, count: count.to_s)
     ).and_return(rummager_response)
 
     rummager = CollectionsAPI.services(:rummager, rummager_double)


### PR DESCRIPTION
The first part of [this story](https://www.pivotaltracker.com/story/show/79185504).

This adds support for paginating the latest changes feed in the Collections API. 

A subsequent page can be requested by providing the `start` parameter as an integer of the number of documents to offset. This is then used to build the request to Rummager in the `LatestChanges` model.

Additionally, we expose the `start` and `total` values from the Rummager response as keys in the `details` hash of the API response (as `documents_start` and `documents_total` respectively).

_Note: Due to the complexity of running this app in the development environment (due to requiring data for the content store, content API and search indexes), I've not tested this fully locally, but the tests all pass for me._
