### PR TITLE
Show the A to Z list if only the "other" group is present.

### DIFF
--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -77,7 +77,7 @@ private
   end
 
   def groups
-    if curated_sector
+    if curated_sector && curated_groups_with_content?
       filtered_groups
     else
       a_to_z_group
@@ -102,8 +102,12 @@ private
     ]
   end
 
+  def curated_groups_with_content?
+    filtered_groups.map { |g| g[:name] } != ["Other"]
+  end
+
   def filtered_groups
-    inflated_groups.reject do |group|
+    @filtered_groups ||= inflated_groups.reject do |group|
       group[:contents].empty?
     end
   end

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe SectorPresenter, type: :model do
     end
   end
 
-  context "with changed documnets" do
+  context "with changed documents" do
     before do
       stub_content_api_with_content
       stub_content_store_with_content

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -257,6 +257,43 @@ RSpec.describe SectorPresenter, type: :model do
     end
   end
 
+  context "when the sector is present and curated with no groups" do
+    before do
+      stub_content_api_with_content
+      stub_content_store_with_content_but_no_groups
+      stub_rummager_with_content
+    end
+
+    it "returns A to Z content" do
+      presenter = SectorPresenter.new("oil-and-gas/offshore")
+
+      expect(presenter).not_to be_empty
+      expect(presenter.to_hash[:details][:groups]).to eq([
+        {
+          name: "A to Z",
+          contents: [
+            {
+              title: "North Sea shipping lanes",
+              web_url: "https://www.example.com/north-sea-shipping-lanes"
+            },
+            {
+              title: "Oil rig safety requirements",
+              web_url: "https://www.example.com/oil-rig-safety-requirements"
+            },
+            {
+              title: "Oil rig staffing",
+              web_url: "https://www.example.com/oil-rig-staffing"
+            },
+            {
+              title: "Undersea piping restrictions",
+              web_url: "https://www.example.com/undersea-piping-restrictions"
+            }
+          ]
+        }
+      ])
+    end
+  end
+
   def find_group(presenter, name)
     presenter.to_hash[:details][:groups].find { |g| g[:name] == name }
   end

--- a/spec/support/helpers/content_store_helpers.rb
+++ b/spec/support/helpers/content_store_helpers.rb
@@ -12,43 +12,70 @@ module ContentStoreHelpers
   end
 
   def stub_content_store_with_content
-    allow(CollectionsAPI.services(:content_store)).to receive(:content_item).with("/oil-and-gas/offshore").and_return({
-      "base_path" => "/oil-and-gas/offshore",
-      "title" => "Offshore",
-      "description" => "Important information about offshore drilling",
+    stub_content_store_with("/oil-and-gas/offshore", {
+      title: "Offshore",
+      description: "Important information about offshore drilling",
+      groups: [
+        {
+          "name" => "Oil rigs",
+          "contents" => [
+            "http://example.com/api/oil-rig-safety-requirements.json",
+            "http://example.com/api/oil-rig-staffing.json"
+          ]
+        },
+        {
+          "name" => "Piping",
+          "contents" => [
+            "http://example.com/api/undersea-piping-restrictions.json",
+            "http://example.com/api/an-untagged-document-about-oil.json"
+          ]
+        },
+        {
+          "name" => "A group with only untagged content",
+          "contents" => [
+            "http://example.com/api/an-untagged-document-about-oil.json"
+          ]
+        },
+        {
+          "name" => "Other",
+          "contents" => [
+            "http://example.com/api/north-sea-shipping-lanes.json"
+          ]
+        }
+      ]
+    })
+  end
+
+  def stub_content_store_with_content_but_no_groups
+    stub_content_store_with("/oil-and-gas/offshore", {
+      title: "Offshore",
+      description: "Important information about offshore drilling",
+      groups: [
+        {
+          "name" => "Other",
+          "contents" => [
+            "http://example.com/api/oil-rig-safety-requirements.json",
+            "http://example.com/api/oil-rig-staffing.json",
+            "http://example.com/api/undersea-piping-restrictions.json",
+            "http://example.com/api/an-untagged-document-about-oil.json",
+            "http://example.com/api/north-sea-shipping-lanes.json"
+          ]
+        }
+      ]
+    })
+  end
+
+  def stub_content_store_with(base_path, options = {})
+    allow(CollectionsAPI.services(:content_store)).to receive(:content_item).with(base_path).and_return({
+      "base_path" => base_path,
+      "title" => options[:title],
+      "description" => options[:description],
       "format" => "specialist_sector",
       "need_ids" => [],
       "public_updated_at"=> "2014-03-04T13:58:11+00:00",
       "updated_at" => "2014-03-04T14:15:17+00:00",
       "details" => {
-        "groups" => [
-          {
-            "name" => "Oil rigs",
-            "contents" => [
-              "http://example.com/api/oil-rig-safety-requirements.json",
-              "http://example.com/api/oil-rig-staffing.json"
-            ]
-          },
-          {
-            "name" => "Piping",
-            "contents" => [
-              "http://example.com/api/undersea-piping-restrictions.json",
-              "http://example.com/api/an-untagged-document-about-oil.json"
-            ]
-          },
-          {
-            "name" => "A group with only untagged content",
-            "contents" => [
-              "http://example.com/api/an-untagged-document-about-oil.json"
-            ]
-          },
-          {
-            "name" => "Other",
-            "contents" => [
-              "http://example.com/api/north-sea-shipping-lanes.json"
-            ]
-          }
-        ]
+        "groups" => options[:groups]
       }
     })
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/82282148

If the topic curation has resulted in only the "other" group being published with any useable content, show in A to Z order instead, with the A to Z heading.

Before:
![screenshot 2014-11-17 14 05 42](https://cloud.githubusercontent.com/assets/109225/5070833/d9c1040e-6e62-11e4-8d91-fba96d68c3c8.png)

After:
![screenshot 2014-11-17 14 05 27](https://cloud.githubusercontent.com/assets/109225/5070837/df315f10-6e62-11e4-9ed0-44c4e9a3929e.png)
