### PR TITLE
Filter news from the sub-topic 'A-Z' list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'plek', '1.8.1'
 gem 'airbrake', '4.0.0'
 
-gem 'gds-api-adapters', '14.3.0'
+gem 'gds-api-adapters', '16.3.4'
 
 gem 'decent_exposure', '2.3.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     factory_girl_rails (4.4.1)
       factory_girl (~> 4.4.0)
       railties (>= 3.0.0)
-    gds-api-adapters (14.3.0)
+    gds-api-adapters (16.3.4)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -109,7 +109,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.3.2)
-    rdoc (4.1.1)
+    rdoc (4.1.2)
       json (~> 1.4)
     rest-client (1.6.8)
       mime-types (~> 1.16)
@@ -166,7 +166,7 @@ DEPENDENCIES
   capistrano-rails
   decent_exposure (= 2.3.2)
   factory_girl_rails
-  gds-api-adapters (= 14.3.0)
+  gds-api-adapters (= 16.3.4)
   jbuilder (~> 2.0)
   plek (= 1.8.1)
   rails (= 4.1.8)

--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -16,6 +16,7 @@ class SectorPresenter
     press_release
     speech
     statement
+    world_location_news_article
   ).to_set
 
   def empty?

--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -98,9 +98,7 @@ private
   end
 
   def filtered_contents
-    sector_content.results.each_with_object([]) do |result, array|
-      array << result unless FORMATS_TO_EXCLUDE.include? result[:format]
-    end
+    sector_content.results.reject { |result| FORMATS_TO_EXCLUDE.include? result[:format] }
   end
 
   def a_to_z_group

--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -9,6 +9,15 @@ class SectorPresenter
     @options = options
   end
 
+  FORMATS_TO_EXCLUDE = %w(
+    fatality_notice
+    government_response
+    news_story
+    press_release
+    speech
+    statement
+  ).to_set
+
   def empty?
     no_sector_content? && no_latest_changes?
   end
@@ -85,7 +94,13 @@ private
   end
 
   def ordered_contents
-    sector_content.results.sort_by {|r| r[:title] }
+    filtered_contents.sort_by { |r| r[:title] }
+  end
+
+  def filtered_contents
+    sector_content.results.each_with_object([]) do |result, array|
+      array << result unless FORMATS_TO_EXCLUDE.include? result[:format]
+    end
   end
 
   def a_to_z_group

--- a/spec/requests/sector_spec.rb
+++ b/spec/requests/sector_spec.rb
@@ -194,6 +194,29 @@ RSpec.describe "Requests for specialist sectors", type: :request do
         ]
       )
     end
+
+    it "excludes content with a format of world_location_news_article" do
+      content_api_has_artefacts_with_a_tag(
+        "specialist_sector",
+        "oil-and-gas/offshore",
+        ["a-world-location-news-article"],
+        artefact: { format: "world_location_news_article" }
+      )
+
+      get_specialist_sector "oil-and-gas/offshore"
+
+      expect(JSON.parse(response.body)["details"]).not_to include(
+        "groups" => [
+          "name" => "A to Z",
+          "contents" => [
+            {
+              "title" => "A world location news article",
+              "web_url" => "http://frontend.test.gov.uk/a-world-location-news-article"
+            },
+          ]
+        ]
+      )
+    end
   end
 
   context "with a curated sector" do

--- a/spec/requests/sector_spec.rb
+++ b/spec/requests/sector_spec.rb
@@ -56,6 +56,144 @@ RSpec.describe "Requests for specialist sectors", type: :request do
         "title" => "Oil and gas"
       )
     end
+
+    it "excludes content with a format of news_story" do
+      content_api_has_artefacts_with_a_tag(
+        "specialist_sector",
+        "oil-and-gas/offshore",
+        ["a-news-story"],
+        artefact: { format: "news_story" }
+      )
+
+      get_specialist_sector "oil-and-gas/offshore"
+
+      expect(JSON.parse(response.body)["details"]).not_to include(
+        "groups" => [
+          "name" => "A to Z",
+          "contents" => [
+            {
+              "title" => "A news story",
+              "web_url" => "http://frontend.test.gov.uk/a-news-story"
+            },
+          ]
+        ]
+      )
+    end
+
+    it "excludes content with a format of press_release" do
+      content_api_has_artefacts_with_a_tag(
+        "specialist_sector",
+        "oil-and-gas/offshore",
+        ["a-press-release"],
+        artefact: { format: "press_release" }
+      )
+
+      get_specialist_sector "oil-and-gas/offshore"
+
+      expect(JSON.parse(response.body)["details"]).not_to include(
+        "groups" => [
+          "name" => "A to Z",
+          "contents" => [
+            {
+              "title" => "A press release",
+              "web_url" => "http://frontend.test.gov.uk/a-press-release"
+            },
+          ]
+        ]
+      )
+    end
+
+    it "excludes content with a format of speech" do
+      content_api_has_artefacts_with_a_tag(
+        "specialist_sector",
+        "oil-and-gas/offshore",
+        ["a-speech"],
+        artefact: { format: "speech" }
+      )
+
+      get_specialist_sector "oil-and-gas/offshore"
+
+      expect(JSON.parse(response.body)["details"]).not_to include(
+        "groups" => [
+          "name" => "A to Z",
+          "contents" => [
+            {
+              "title" => "A speech",
+              "web_url" => "http://frontend.test.gov.uk/a-speech"
+            },
+          ]
+        ]
+      )
+    end
+
+    it "excludes content with a format of statement" do
+      content_api_has_artefacts_with_a_tag(
+        "specialist_sector",
+        "oil-and-gas/offshore",
+        ["a-statement"],
+        artefact: { format: "statement" }
+      )
+
+      get_specialist_sector "oil-and-gas/offshore"
+
+      expect(JSON.parse(response.body)["details"]).not_to include(
+        "groups" => [
+          "name" => "A to Z",
+          "contents" => [
+            {
+              "title" => "A statement",
+              "web_url" => "http://frontend.test.gov.uk/a-statement"
+            },
+          ]
+        ]
+      )
+    end
+
+    it "excludes content with a format of government_response" do
+      content_api_has_artefacts_with_a_tag(
+        "specialist_sector",
+        "oil-and-gas/offshore",
+        ["a-government-response"],
+        artefact: { format: "government_response" }
+      )
+
+      get_specialist_sector "oil-and-gas/offshore"
+
+      expect(JSON.parse(response.body)["details"]).not_to include(
+        "groups" => [
+          "name" => "A to Z",
+          "contents" => [
+            {
+              "title" => "A government response",
+              "web_url" => "http://frontend.test.gov.uk/a-government-response"
+            },
+          ]
+        ]
+      )
+    end
+
+    it "excludes content with a format of government_response" do
+      content_api_has_artefacts_with_a_tag(
+        "specialist_sector",
+        "oil-and-gas/offshore",
+        ["a-fatality-notice"],
+        artefact: { format: "fatality_notice" }
+      )
+
+      get_specialist_sector "oil-and-gas/offshore"
+
+      expect(JSON.parse(response.body)["details"]).not_to include(
+        "groups" => [
+          "name" => "A to Z",
+          "contents" => [
+            {
+              "title" => "A fatality notice",
+              "web_url" => "http://frontend.test.gov.uk/a-fatality-notice"
+            },
+          ]
+        ]
+      )
+    end
   end
 
   context "with a curated sector" do


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/82281582

Exclude news articles from the 'A-Z' list, mitigating the user
impact of a department tagging loosely related news content to a
sub-topic when there is no curated list.
