### PR TITLE
Fix display of topic with empty groups in content-store.

### DIFF
--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -117,7 +117,7 @@ private
   end
 
   def curated_groups_with_content?
-    filtered_groups.map { |g| g[:name] } != ["Other"]
+    filtered_groups.any? && filtered_groups.map { |g| g[:name] } != ["Other"]
   end
 
   def filtered_groups

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -260,11 +260,12 @@ RSpec.describe SectorPresenter, type: :model do
   context "when the sector is present and curated with no groups" do
     before do
       stub_content_api_with_content
-      stub_content_store_with_content_but_no_groups
       stub_rummager_with_content
     end
 
     it "returns A to Z content" do
+      stub_content_store_with_content_but_no_groups
+
       presenter = SectorPresenter.new("oil-and-gas/offshore")
 
       expect(presenter).not_to be_empty
@@ -291,6 +292,38 @@ RSpec.describe SectorPresenter, type: :model do
           ]
         }
       ])
+    end
+
+    it "returns A to Z content with empty groups in content-store" do
+      stub_content_store_with_content_but_empty_groups
+
+      presenter = SectorPresenter.new("oil-and-gas/offshore")
+
+      expect(presenter).not_to be_empty
+      expect(presenter.to_hash[:details][:groups]).to eq([
+        {
+          name: "A to Z",
+          contents: [
+            {
+              title: "North Sea shipping lanes",
+              web_url: "https://www.example.com/north-sea-shipping-lanes"
+            },
+            {
+              title: "Oil rig safety requirements",
+              web_url: "https://www.example.com/oil-rig-safety-requirements"
+            },
+            {
+              title: "Oil rig staffing",
+              web_url: "https://www.example.com/oil-rig-staffing"
+            },
+            {
+              title: "Undersea piping restrictions",
+              web_url: "https://www.example.com/undersea-piping-restrictions"
+            }
+          ]
+        }
+      ])
+
     end
   end
 

--- a/spec/support/helpers/content_store_helpers.rb
+++ b/spec/support/helpers/content_store_helpers.rb
@@ -46,6 +46,14 @@ module ContentStoreHelpers
     })
   end
 
+  def stub_content_store_with_content_but_empty_groups
+    stub_content_store_with("/oil-and-gas/offshore", {
+      title: "Offshore",
+      description: "Important information about offshore drilling",
+      groups: [],
+    })
+  end
+
   def stub_content_store_with_content_but_no_groups
     stub_content_store_with("/oil-and-gas/offshore", {
       title: "Offshore",


### PR DESCRIPTION
Now that we're sending items to the content-store for all topics, the
ones with no curated groups have an empty groups array.  The log here
wasn't handling that case, and therefore assumed that they had curated
groups, and returned an empty list of groups.  This resulted in a blank
page on the frontend.
