### PR TITLE
Forward `beta` flag

### DIFF
--- a/app/models/curated_sector.rb
+++ b/app/models/curated_sector.rb
@@ -29,6 +29,10 @@ class CuratedSector
   end
 
   def groups
-    @content_item["details"].with_indifferent_access[:groups]
+    details[:groups]
+  end
+
+  def details
+    @content_item["details"].with_indifferent_access
   end
 end

--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -31,6 +31,7 @@ class SectorPresenter
         title: sector_content.title,
         parent: sector_content.parent,
         details: {
+          beta: beta,
           groups: groups,
           documents: documents,
           documents_start: latest_changes_content.start,
@@ -48,10 +49,12 @@ private
 
   attr_reader :options
 
+  # Represents the content coming from *Content API*
   def sector_content
     @sector_content ||= SectorContent.find(@slug)
   end
 
+  # Represents the content coming from *Content Store*
   def curated_sector
     @curated_sector ||= CuratedSector.find(@slug)
   end
@@ -84,6 +87,12 @@ private
 
   def full_url(link)
     Plek.new.website_root+link
+  end
+
+  def beta
+    if curated_sector
+      curated_sector.details[:beta]
+    end || false
   end
 
   def groups

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe SectorPresenter, type: :model do
   end
 
   context "when only the sector is present" do
+    # There is only data coming from content-api, not content-store.
     before do
       stub_content_api_with_content
       stub_rummager_with_content
@@ -43,6 +44,7 @@ RSpec.describe SectorPresenter, type: :model do
       expect(presenter.to_hash).to include(
         title: "Offshore",
         details: {
+          beta: false, # Topics without a content-store entry are never in beta.
           groups: [
             {
               name: "A to Z",
@@ -105,6 +107,7 @@ RSpec.describe SectorPresenter, type: :model do
       expect(presenter.to_hash).to include({
         title: "Offshore",
         details: {
+          beta: true, # Beta flag is set in content store.
           groups: [
             {
               name: "Oil rigs",
@@ -180,6 +183,7 @@ RSpec.describe SectorPresenter, type: :model do
       expect(presenter.to_hash).to include({
         title: "Offshore",
         details: {
+          beta: true, # Beta flag is set in content store.
           groups: [
             {
               name: "Oil rigs",

--- a/spec/support/helpers/content_store_helpers.rb
+++ b/spec/support/helpers/content_store_helpers.rb
@@ -16,6 +16,7 @@ module ContentStoreHelpers
       title: "Offshore",
       description: "Important information about offshore drilling",
       details: {
+        beta: true,
         groups: [
           {
             "name" => "Oil rigs",

--- a/spec/support/helpers/content_store_helpers.rb
+++ b/spec/support/helpers/content_store_helpers.rb
@@ -15,34 +15,36 @@ module ContentStoreHelpers
     stub_content_store_with("/oil-and-gas/offshore", {
       title: "Offshore",
       description: "Important information about offshore drilling",
-      groups: [
-        {
-          "name" => "Oil rigs",
-          "contents" => [
-            "http://example.com/api/oil-rig-safety-requirements.json",
-            "http://example.com/api/oil-rig-staffing.json"
-          ]
-        },
-        {
-          "name" => "Piping",
-          "contents" => [
-            "http://example.com/api/undersea-piping-restrictions.json",
-            "http://example.com/api/an-untagged-document-about-oil.json"
-          ]
-        },
-        {
-          "name" => "A group with only untagged content",
-          "contents" => [
-            "http://example.com/api/an-untagged-document-about-oil.json"
-          ]
-        },
-        {
-          "name" => "Other",
-          "contents" => [
-            "http://example.com/api/north-sea-shipping-lanes.json"
-          ]
-        }
-      ]
+      details: {
+        groups: [
+          {
+            "name" => "Oil rigs",
+            "contents" => [
+              "http://example.com/api/oil-rig-safety-requirements.json",
+              "http://example.com/api/oil-rig-staffing.json"
+            ]
+          },
+          {
+            "name" => "Piping",
+            "contents" => [
+              "http://example.com/api/undersea-piping-restrictions.json",
+              "http://example.com/api/an-untagged-document-about-oil.json"
+            ]
+          },
+          {
+            "name" => "A group with only untagged content",
+            "contents" => [
+              "http://example.com/api/an-untagged-document-about-oil.json"
+            ]
+          },
+          {
+            "name" => "Other",
+            "contents" => [
+              "http://example.com/api/north-sea-shipping-lanes.json"
+            ]
+          }
+        ]
+      }
     })
   end
 
@@ -50,7 +52,9 @@ module ContentStoreHelpers
     stub_content_store_with("/oil-and-gas/offshore", {
       title: "Offshore",
       description: "Important information about offshore drilling",
-      groups: [],
+      details: {
+        groups: [],
+      }
     })
   end
 
@@ -58,18 +62,20 @@ module ContentStoreHelpers
     stub_content_store_with("/oil-and-gas/offshore", {
       title: "Offshore",
       description: "Important information about offshore drilling",
-      groups: [
-        {
-          "name" => "Other",
-          "contents" => [
-            "http://example.com/api/oil-rig-safety-requirements.json",
-            "http://example.com/api/oil-rig-staffing.json",
-            "http://example.com/api/undersea-piping-restrictions.json",
-            "http://example.com/api/an-untagged-document-about-oil.json",
-            "http://example.com/api/north-sea-shipping-lanes.json"
-          ]
-        }
-      ]
+      details: {
+        groups: [
+          {
+            "name" => "Other",
+            "contents" => [
+              "http://example.com/api/oil-rig-safety-requirements.json",
+              "http://example.com/api/oil-rig-staffing.json",
+              "http://example.com/api/undersea-piping-restrictions.json",
+              "http://example.com/api/an-untagged-document-about-oil.json",
+              "http://example.com/api/north-sea-shipping-lanes.json"
+            ]
+          }
+        ]
+      }
     })
   end
 
@@ -82,9 +88,7 @@ module ContentStoreHelpers
       "need_ids" => [],
       "public_updated_at"=> "2014-03-04T13:58:11+00:00",
       "updated_at" => "2014-03-04T14:15:17+00:00",
-      "details" => {
-        "groups" => options[:groups]
-      }
+      "details" => options[:details]
     })
   end
 end


### PR DESCRIPTION
Topics in the `content-store` now have a beta flag. We want to use that in the `collections` app.

Trello: https://trello.com/c/H9UMp051/139-allow-topic-subtopics-to-be-labelled-as-beta
