### PR TITLE
Fix matching of grouped items in dev and preview

### DIFF
--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -145,8 +145,9 @@ private
   end
 
   def find_content(api_url)
+    api_path = URI(api_url).path
     sector_content.results.find do |content|
-      content[:id] == api_url
+      URI(content[:id]).path == api_path
     end
   end
 


### PR DESCRIPTION
Items in groups in topics are represented in the content store by the
API url of the content.  Matching this exactly only works in production.
This commit makes the matching work in development and preview
environments by just matching on the path of the content.

This change doesn't break any tests.  I haven't added any tests since
I've tested manually, and this app is in the process of being
decommissioned.
